### PR TITLE
Fix compiler warnings not related to ERC-4626 staking vault

### DIFF
--- a/smart-contract/contracts/GatewayToken.sol
+++ b/smart-contract/contracts/GatewayToken.sol
@@ -225,7 +225,7 @@ contract GatewayToken is
         _handleCharge(FeeType.ISSUE, network, gatekeeper, partiesInCharge);
     }
 
-    function revoke(uint tokenId, ChargeParties memory partiesInCharge) external virtual override {
+    function revoke(uint tokenId) external virtual override {
         _checkGatekeeper(slotOf(tokenId));
 
         _tokenStates[tokenId] = TokenState.REVOKED;
@@ -238,7 +238,7 @@ contract GatewayToken is
      * @dev Triggers to freeze gateway token
      * @param tokenId Gateway token id
      */
-    function freeze(uint tokenId, ChargeParties memory partiesInCharge) external virtual {
+    function freeze(uint tokenId) external virtual {
         _checkGatekeeper(slotOf(tokenId));
 
         _freeze(tokenId);
@@ -311,7 +311,7 @@ contract GatewayToken is
      * Checks owner has any token on gateway token contract, `tokenId` still active, and not expired.
      */
     function verifyToken(address owner, uint network) external virtual returns (bool) {
-        (uint[] memory tokenIds, uint count) = _getTokenIdsByOwnerAndNetwork(owner, network, true);
+        (, uint count) = _getTokenIdsByOwnerAndNetwork(owner, network, true);
         return count > 0;
     }
 
@@ -478,7 +478,7 @@ contract GatewayToken is
         }
     }
 
-    function _resolveTotalFeeAmount(FeeType feeType, IGatewayGatekeeper.GatekeeperNetworkData memory gatekeeperData, IGatewayNetwork.GatekeeperNetworkData memory networkData) internal returns(uint256, uint16) {
+    function _resolveTotalFeeAmount(FeeType feeType, IGatewayGatekeeper.GatekeeperNetworkData memory gatekeeperData, IGatewayNetwork.GatekeeperNetworkData memory networkData) internal pure returns(uint256, uint16) {
         uint256 totalFeeAmount;
         uint16 networkFeeBps;
 

--- a/smart-contract/contracts/interfaces/IERC721Freezable.sol
+++ b/smart-contract/contracts/interfaces/IERC721Freezable.sol
@@ -18,7 +18,7 @@ interface IERC721Freezable {
      * @dev Triggers to freeze gateway token
      * @param tokenId Gateway token id
      */
-    function freeze(uint256 tokenId, ChargeParties memory partiesInCharge) external;
+    function freeze(uint256 tokenId) external;
 
     /**
      * @dev Triggers to unfreeze gateway token

--- a/smart-contract/contracts/interfaces/IERC721Revokable.sol
+++ b/smart-contract/contracts/interfaces/IERC721Revokable.sol
@@ -13,5 +13,5 @@ interface IERC721Revokable {
      * @dev Triggers to revoke gateway token
      * @param tokenId Gateway token id
      */
-    function revoke(uint256 tokenId, ChargeParties memory partiesInCharge) external;
+    function revoke(uint256 tokenId) external;
 }

--- a/smart-contract/test/contracts/StubMultisig.sol
+++ b/smart-contract/test/contracts/StubMultisig.sol
@@ -15,9 +15,4 @@ contract StubMultisig {
         _gatewayTokenContract = gatewayTokenContract;
         _gatekeeperNetwork = gatekeeperNetwork;
     }
-
-    // call the gateway token contract transferDAOMembership function
-    function reassignOwnership(address newOwner) external {
-        IGatewayToken gatewayToken = IGatewayToken(_gatewayTokenContract);
-    }
 }

--- a/smart-contract/test/contracts/v0/GatewayTokenV0.sol
+++ b/smart-contract/test/contracts/v0/GatewayTokenV0.sol
@@ -171,16 +171,8 @@ contract GatewayTokenV0 is
         _freeze(tokenId);
     }
 
-    function freeze(uint256 tokenId, ChargeParties calldata partiesInCharge) external override {
-
-    }
-
-    function revoke(uint256 tokenId, ChargeParties calldata partiesInCharge) external override {
-
-    }
-
     function unfreeze(uint256 tokenId, ChargeParties calldata partiesInCharge) external {
-        
+        _unfreeze(tokenId);
     }
 
     /**

--- a/smart-contract/test/gatewayToken.test.ts
+++ b/smart-contract/test/gatewayToken.test.ts
@@ -1132,7 +1132,7 @@ describe('GatewayToken', async () => {
         tokenSender: ZERO_ADDRESS,
       });
       const [tokenId] = await gatewayToken.getTokenIdsByOwnerAndNetwork(userToBeFrozen.address, gkn1, true);
-      await gatewayToken.connect(gatekeeper).freeze(tokenId, { tokenSender: ZERO_ADDRESS, recipient: gatekeeper.address});
+      await gatewayToken.connect(gatekeeper).freeze(tokenId);
       expect(await checkVerification(userToBeFrozen.address, gkn1)).to.be.false;
 
       // create a forwarded metatx to unfreeze the user
@@ -1145,7 +1145,7 @@ describe('GatewayToken', async () => {
           .connect(alice)
           .execute(forwardedUnfreezeTx.request, forwardedUnfreezeTx.signature, { gasLimit: 1000000 })
       ).wait;
-      await gatewayToken.connect(gatekeeper).freeze(tokenId, { tokenSender: ZERO_ADDRESS, recipient: gatekeeper.address});
+      await gatewayToken.connect(gatekeeper).freeze(tokenId);
       expect(await checkVerification(userToBeFrozen.address, gkn1)).to.be.false;
 
       // cannot replay the unfreeze transaction

--- a/smart-contract/test/gatewayToken.test.ts
+++ b/smart-contract/test/gatewayToken.test.ts
@@ -783,22 +783,22 @@ describe('GatewayToken', async () => {
     });
 
     it('freeze token', async () => {
-      await gatewayToken.connect(gatekeeper).freeze(dummyWalletTokenId, { tokenSender: ZERO_ADDRESS, recipient: gatekeeper.address});
+      await gatewayToken.connect(gatekeeper).freeze(dummyWalletTokenId);
 
       return expect(await checkVerification(dummyWallet, gkn1)).to.be.false;
     });
 
     it('freeze token - revert if already frozen', async () => {
-      await gatewayToken.connect(gatekeeper).freeze(dummyWalletTokenId, { tokenSender: ZERO_ADDRESS, recipient: gatekeeper.address});
+      await gatewayToken.connect(gatekeeper).freeze(dummyWalletTokenId);
 
-      await expect(gatewayToken.connect(gatekeeper).freeze(dummyWalletTokenId, { tokenSender: ZERO_ADDRESS, recipient: gatekeeper.address})).to.be.revertedWithCustomError(
+      await expect(gatewayToken.connect(gatekeeper).freeze(dummyWalletTokenId)).to.be.revertedWithCustomError(
         gatewayToken,
         'GatewayToken__TokenDoesNotExistOrIsInactive',
       );
     });
 
     it('unfreeze token', async () => {
-      await gatewayToken.connect(gatekeeper).freeze(dummyWalletTokenId, { tokenSender: ZERO_ADDRESS, recipient: gatekeeper.address});
+      await gatewayToken.connect(gatekeeper).freeze(dummyWalletTokenId);
 
       await gatewayToken.connect(gatekeeper).unfreeze(dummyWalletTokenId, { tokenSender: ZERO_ADDRESS, recipient: gatekeeper.address});
 
@@ -820,11 +820,11 @@ describe('GatewayToken', async () => {
       });
       const dummyWalletTokenIds = await gatewayToken.getTokenIdsByOwnerAndNetwork(alice.address, gkn1, true);
 
-      await gatewayToken.connect(gatekeeper).freeze(dummyWalletTokenIds[0], { tokenSender: ZERO_ADDRESS, recipient: gatekeeper.address});
+      await gatewayToken.connect(gatekeeper).freeze(dummyWalletTokenIds[0]);
 
       expect(await checkVerification(alice.address, gkn1)).to.be.true;
 
-      await gatewayToken.connect(gatekeeper).freeze(dummyWalletTokenIds[1], { tokenSender: ZERO_ADDRESS, recipient: gatekeeper.address});
+      await gatewayToken.connect(gatekeeper).freeze(dummyWalletTokenIds[1]);
 
       expect(await checkVerification(alice.address, gkn1)).to.be.false;
 
@@ -888,7 +888,7 @@ describe('GatewayToken', async () => {
     });
 
     it('revoke a token', async () => {
-      await gatewayToken.connect(gatekeeper).revoke(dummyWalletTokenId, { tokenSender: ZERO_ADDRESS, recipient: gatekeeper.address});
+      await gatewayToken.connect(gatekeeper).revoke(dummyWalletTokenId);
       return expect(await checkVerification(dummyWallet, gkn1)).to.be.false;
     });
 
@@ -911,7 +911,7 @@ describe('GatewayToken', async () => {
       });
       const dummyWalletTokenIds = await gatewayToken.getTokenIdsByOwnerAndNetwork(dummyWallet, gkn1, true);
 
-      await gatewayToken.connect(gatekeeper).revoke(dummyWalletTokenIds[0], { tokenSender: ZERO_ADDRESS, recipient: gatekeeper.address});
+      await gatewayToken.connect(gatekeeper).revoke(dummyWalletTokenIds[0]);
 
       let validity = await gatewayToken.callStatic['verifyToken(uint256)'](dummyWalletTokenIds[0]);
       expect(validity).to.equal(false);


### PR DESCRIPTION
- Not sure how to add inline compiler comments to disable on the methods we need to override for the ERC-4626 vault contract.