### PR TITLE
Add a description field to networks

### DIFF
--- a/gateway-eth-ts/src/service/GatewayNetwork.ts
+++ b/gateway-eth-ts/src/service/GatewayNetwork.ts
@@ -7,6 +7,7 @@ import {
 } from "../contracts/typechain-types";
 import { BigNumberish, ContractTransaction, Wallet, ethers } from "ethers";
 import { DEFAULT_GAS_LIMIT } from "../utils/constants";
+import { defaultAbiCoder } from "@ethersproject/abi";
 
 export enum GatewayNetworkFeatures {
   REMOVE_GATEKEEPER_INVALIDATES_TOKENS
@@ -103,6 +104,14 @@ export class GatewayNetworkClass {
   async updateFees(networkName: string, newNetworkFeeConfig: IGatewayNetwork.NetworkFeesBpsStruct): Promise<ContractTransaction> {
     return await this.gatewayNetworkContract.updateFees(
         newNetworkFeeConfig,
+        networkName,
+      { gasLimit: DEFAULT_GAS_LIMIT }
+    );
+  }
+
+  async updateDescription(description: string, networkName: string): Promise<ContractTransaction> {
+    return await this.gatewayNetworkContract.updateDescription(
+        defaultAbiCoder.encode(['string'],[description]),
         networkName,
       { gasLimit: DEFAULT_GAS_LIMIT }
     );

--- a/gateway-eth-ts/test/integration/gatewayNetwork.test.ts
+++ b/gateway-eth-ts/test/integration/gatewayNetwork.test.ts
@@ -5,6 +5,7 @@ import { Wallet, ethers } from "ethers";
 import { BaseProvider } from "@ethersproject/providers";
 import { BNB_TESTNET_CONTRACT_ADDRESSES, ZERO_ADDRESS, gatekeeperOneTestnetWallet, gatekeeperTwoTestnetWallet, initTestNetwork, testNetworkName, testNetworkNameWithErc20Fees } from "../utils";
 import { GatewayNetwork, GatewayNetwork__factory } from "../../src/contracts/typechain-types";
+import { defaultAbiCoder } from "@ethersproject/abi";
 
 
 dotenv.config();
@@ -99,6 +100,14 @@ describe("Gateway Network TS class", function () {
             const network = await gatewayNetworkClient.getNetwork(networkId.toString());
 
             assert.equal(network.passExpireDurationInSeconds, newDefaultTime);
+        }).timeout(15000);
+
+        it("should successfully update the description of test network", async function () {
+            const newDescription = 'new description';
+            await gatewayNetworkClient.updateDescription(newDescription,testNetworkNameWithErc20Fees);
+
+            const networkId = await gatewayNetworkClient.getNetworkId(testNetworkNameWithErc20Fees);
+            const network = await gatewayNetworkClient.getNetwork(networkId.toString());
         }).timeout(15000);
 
         it("should successfully update the networks fee % of test network", async function () {

--- a/gateway-eth-ts/test/unit/issuer.test.ts
+++ b/gateway-eth-ts/test/unit/issuer.test.ts
@@ -28,7 +28,7 @@ nock(TEST_MALFORMED_URL_SERVICE_ENDPOINT)
 .get(ISSUER_CONFIG_PATH)
 .reply(200, {...TEST_ISSUER_CONFIG, gatewayIssuerEndpoint: "ht:/t/sd.do-d.so"});
 
-describe.only("Issuer Config Utility", () => {
+describe("Issuer Config Utility", () => {
 
     it('should correctly resolve test issuer config', async () => {
         const issuerConfig = await resolveIssuerConfigFromServiceEndpoint(TEST_VALID_SERVICE_ENDPOINT);

--- a/smart-contract/contracts/GatewayNetwork.sol
+++ b/smart-contract/contracts/GatewayNetwork.sol
@@ -205,6 +205,10 @@ contract GatewayNetwork is ParameterizedAccessControl, IGatewayNetwork, UUPSUpgr
         _networks[networkName].networkFee = fees;
         _networks[networkName].lastFeeUpdateTimestamp = block.timestamp;
     }
+    
+    function updateDescription(bytes calldata description, bytes32 networkName) external override onlyPrimaryNetworkAuthority(networkName) {
+        _networks[networkName].description = description;
+    }
 
     function resetNetworkFeeUpdateTime(bytes32 networkName) external override onlySuperAdmin {
         require(_networks[networkName].primaryAuthority != address(0), "Network does not exist");

--- a/smart-contract/contracts/interfaces/IGatewayNetwork.sol
+++ b/smart-contract/contracts/interfaces/IGatewayNetwork.sol
@@ -45,6 +45,7 @@ abstract contract  IGatewayNetwork {
 
         address[] gatekeepers;
         uint256 lastFeeUpdateTimestamp;
+        bytes description;
     }
 
     enum NetworkFeature {
@@ -80,6 +81,7 @@ abstract contract  IGatewayNetwork {
     function claimPrimaryAuthority(bytes32 networkName) external virtual;
     function updateNetworkFeatures(uint256 newFeatureMask, bytes32 networkName) external virtual;
     function updateFees(NetworkFeesBps calldata fees, bytes32 networkName) external virtual;
+    function updateDescription(bytes calldata description, bytes32 networkName) external virtual;
     function resetNetworkFeeUpdateTime(bytes32 networkName) external virtual;
     function networkHasFeature(bytes32 networkName, NetworkFeature feature) public view virtual returns (bool);
     function getNetwork(uint networkId) external view virtual returns(GatekeeperNetworkData memory);

--- a/smart-contract/test/gatewayGatekeeper.test.ts
+++ b/smart-contract/test/gatewayGatekeeper.test.ts
@@ -15,6 +15,7 @@ import {
     DummyERC20__factory, 
 } from '../typechain-types' ;
 import { utils } from 'ethers';
+import { defaultNetworkDescription } from './utils/network';
 
 describe('Gatekeeper', () => {
     let primaryAuthority: SignerWithAddress;
@@ -42,7 +43,8 @@ describe('Gatekeeper', () => {
             networkFee: {issueFee: 0, refreshFee: 0, expireFee: 0, freezeFee: 0},
             supportedToken: ZERO_ADDRESS,
             gatekeepers: gatekeepers ? gatekeepers : [],
-            lastFeeUpdateTimestamp: 0
+            lastFeeUpdateTimestamp: 0,
+            description: defaultNetworkDescription
         }
     }
 

--- a/smart-contract/test/gatewayToken.test.ts
+++ b/smart-contract/test/gatewayToken.test.ts
@@ -24,6 +24,7 @@ import {
   DummyERC20__factory,
   ChargeHandler
 } from '../typechain-types' ;
+import { defaultNetworkDescription } from './utils/network';
 
 describe('GatewayToken', async () => {
   let identityCom: SignerWithAddress;
@@ -94,7 +95,8 @@ describe('GatewayToken', async () => {
         networkFee: {issueFee: 0, refreshFee: 0, expireFee: 0, freezeFee: 0},
         supportedToken: supportedToken ? supportedToken : ZERO_ADDRESS,
         gatekeepers: gatekeepers ? gatekeepers : [],
-        lastFeeUpdateTimestamp: 0
+        lastFeeUpdateTimestamp: 0,
+        description: defaultNetworkDescription
     }
   }
 

--- a/smart-contract/test/utils/network.ts
+++ b/smart-contract/test/utils/network.ts
@@ -1,0 +1,3 @@
+import { toBytes32 } from "./strings";
+
+export const defaultNetworkDescription = toBytes32("Default network description");


### PR DESCRIPTION
- [x] Added new field (`description`) to the `GatekeeperNetworkData` struct that represents a networks on-chain state
- [x] Added method to allow the primary authority update the value
- [x] Updated ts-client to include new functionallity